### PR TITLE
Docs(fe): 절대경로 인식 오류 수정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    },
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from "path"
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: [{ find: '~',
-    replacement: path.resolve(__dirname, "/src") }]
+    alias: { "~": path.resolve(__dirname, "./src") }
   }
-})
+});


### PR DESCRIPTION
 vite가 초기에 설정한 절대경로 별칭("~")을 인식하지 못해 vite.config.ts 파일과 tsconfig.json 파일을 수정하였습니다.